### PR TITLE
Add @types/eslint (same as in official stacks)

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@cloudflare/workers-types": "^3.19.0",
     "@remix-run/dev": "^1.15.0",
     "@remix-run/eslint-config": "^1.15.0",
+    "@types/eslint": "^8.37.0",
     "@types/react": "^18.0.35",
     "@types/react-dom": "^18.0.11",
     "@types/react-grid-layout": "^1.3.2",


### PR DESCRIPTION
For me (WebStorm), my IDE couldn't use the eslint and displayed errors all the time. I compared with official stacks and this seemed to be missing, after installing types and restarting the IDE, it worked.